### PR TITLE
Fix Node cache path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: site/package-lock.json
       - name: Install dependencies
         run: npm install
         working-directory: site

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -25,16 +25,19 @@ jobs:
         uses: actions/checkout@v4
       - name: Detect package manager
         id: detect-package-manager
+        working-directory: site
         run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+          if [ -f "yarn.lock" ]; then
             echo "manager=yarn" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
             echo "runner=yarn" >> $GITHUB_OUTPUT
+            echo "cache_file=yarn.lock" >> $GITHUB_OUTPUT
             exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
+          elif [ -f "package.json" ]; then
             echo "manager=npm" >> $GITHUB_OUTPUT
             echo "command=ci" >> $GITHUB_OUTPUT
             echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            echo "cache_file=package-lock.json" >> $GITHUB_OUTPUT
             exit 0
           else
             echo "Unable to determine package manager"
@@ -45,6 +48,7 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache-dependency-path: site/${{ steps.detect-package-manager.outputs.cache_file }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
@@ -55,6 +59,7 @@ jobs:
           static_site_generator: next
       - name: Restore cache
         uses: actions/cache@v4
+        working-directory: site
         with:
           path: |
             .next/cache
@@ -64,13 +69,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
+        working-directory: site
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
+        working-directory: site
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./out
+          path: ./site/out
 
   # Deployment job
   deploy:


### PR DESCRIPTION
## Summary
- fix Node cache path in workflow files for correct lockfile location
- run lint tests

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854403a901c8325b2d4c293c79cb56c